### PR TITLE
fix: esm error

### DIFF
--- a/packages/papupata/package.json
+++ b/packages/papupata/package.json
@@ -53,7 +53,8 @@
     "./invokers/test": "./dist/main/testInvoker.js",
     "./ValidationError": "./dist/main/PapupataValidationError.js",
     "./config": "./dist/main/config.js",
-    "./dist/main/common-types": "./dist/main/common-types/index.js"
+    "./dist/main/common-types": "./dist/main/common-types/index.js",
+    "./dist/main/responderTypes": "./dist/main/responderTypes.js"
   },
   "scripts": {
     "build": "npx tsc --project tsconfig.json",

--- a/packages/papupata/src/main/index.ts
+++ b/packages/papupata/src/main/index.ts
@@ -19,6 +19,7 @@ export type PapupataMiddleware<RequestType = Request, RouteOptions = void> = Pap
   RequestType,
   RouteOptions
 >
+export * from './responderTypes'
 
 interface API {
   unmock(): void


### PR DESCRIPTION
This fixes a type error in a project (A) that uses another project (B) that uses papupata to declare its apis. The project structure looks like this

```yaml
A:
  - B
    - papupata
```

The following error happened when transpiling with the following settings:

```jsonc
{
  // tsconfig.json
  "include": ["./src"],
  "compilerOptions": {
    "types": [],
    "strict": true,
    "outDir": "dist/",
    "declaration": true,
    "rootDir": "src",
    "module": "NodeNext",
    "target": "ESNext",
    "strictNullChecks": true,
    "composite": true
  }
}
```

```ts
❯ npx tsc --watch --noEmit
[10.09.28] Starting compilation in watch mode...

../../../../misc/moro/packages/api/lib/apis/crud/generic.d.ts:8:18 - error TS2307: Cannot find module 'papupata/dist/main/responderTypes' or its corresponding type declarations.

8     list: import("papupata/dist/main/responderTypes").DeclaredAPI<{}, {}, {}, {}, {
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../../../../misc/moro/packages/api/lib/apis/crud/generic.d.ts:35:20 - error TS2307: Cannot find module 'papupata/dist/main/responderTypes' or its corresponding type declarations.

35     getOne: import("papupata/dist/main/responderTypes").DeclaredAPI<{}, {
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../../../../misc/moro/packages/api/lib/apis/crud/generic.d.ts:38:21 - error TS2307: Cannot find module 'papupata/dist/main/responderTypes' or its corresponding type declarations.

38     getMany: import("papupata/dist/main/responderTypes").DeclaredAPI<{}, {}, {}, {}, {
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../../../../misc/moro/packages/api/lib/apis/crud/generic.d.ts:43:20 - error TS2307: Cannot find module 'papupata/dist/main/responderTypes' or its corresponding type declarations.

43     update: import("papupata/dist/main/responderTypes").DeclaredAPI<{}, {
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../../../../misc/moro/packages/api/lib/apis/crud/generic.d.ts:46:20 - error TS2307: Cannot find module 'papupata/dist/main/responderTypes' or its corresponding type declarations.

46     create: import("papupata/dist/main/responderTypes").DeclaredAPI<{}, {}, {}, {}, Omit<TData, "id"> extends infer T_2 ? T_2 extends Omit<TData, "id"> ? T_2 extends import("zod").ZodTypeAny ? import("zod").TypeOf<T_2> : T_2 : never : never, Omit<TData, "id"> extends infer T_3 ? T_3 extends Omit<TData, "id"> ? T_3 extends import("zod").ZodTypeAny ? import("zod").TypeOf<T_3> : T_3 : never : never, TRequestOptions, TReq, TData extends import("zod").ZodTypeAny ? import("zod").TypeOf<TData> : TData, TData extends import("zod").ZodTypeAny ? import("zod").TypeOf<TData> : TData, RouteOptions>;
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[10.09.29] Found 5 errors. Watching for file changes.
```